### PR TITLE
修改node1下的配置路径错误&修改config.toml配置文件端口

### DIFF
--- a/docs/manual/distributed_storage.md
+++ b/docs/manual/distributed_storage.md
@@ -168,7 +168,7 @@ group.[群组].ini配置文件中，和本特性相关的是MySQL的配置信息
 
 ### 修改node1下的group.1.ini配置
 
-修改~/fisco/nodes/127.0.0.1/node0/conf/group.1.ini[storage]段的内容，新增如下内容。db_passwd为对应的密码。
+修改~/fisco/nodes/127.0.0.1/node1/conf/group.1.ini[storage]段的内容，新增如下内容。db_passwd为对应的密码。
 ```bash
     	db_ip=127.0.0.1
     	db_port=3306
@@ -247,7 +247,7 @@ cp nodes/127.0.0.1/sdk/* console/conf/
 将~/fisco/console/conf/config.toml修改为如下配置(部分信息)
 ```bash
 [network]
-peers=["127.0.0.1:20300", "127.0.0.1:20301"]    # The peer list to connect
+peers=["127.0.0.1:20200", "127.0.0.1:20201"]    # The peer list to connect与构建链当时的端口保持一致
 ```
 #### 启用控制台
 ```bash


### PR DESCRIPTION
1.### 修改node1下的group.1.ini配置  node0->node1
2.#### 修改配置文件
将~/fisco/console/conf/config.toml修改为如下配置(部分信息)
peers=["127.0.0.1:20200", "127.0.0.1:20201"]   20300->20200,20301->20201